### PR TITLE
Update goodix.c

### DIFF
--- a/drivers/input/touchscreen/goodix.c
+++ b/drivers/input/touchscreen/goodix.c
@@ -145,6 +145,29 @@ static const struct dmi_system_id rotated_screen[] = {
 	{}
 };
 
+/*
+ * Those tablets have their x coordinate inverted
+ */
+static const struct dmi_system_id inverted_x_screen[] = {
+#if defined(CONFIG_DMI) && defined(CONFIG_X86)
+	{
+		.ident = "Cube I15-TC",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Cube"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "I15-TC")
+		}
+	},
+	{
+		.ident = "Cube I15-TFL",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Cube"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "I15-TFL")
+		},
+	},
+#endif
+	{}
+};
+
 /**
  * goodix_i2c_read - read data from a register of the i2c slave device.
  *
@@ -707,6 +730,12 @@ static int goodix_configure_dev(struct goodix_ts_data *ts)
 		ts->prop.invert_y = true;
 		dev_dbg(&ts->client->dev,
 			"Applying '180 degrees rotated screen' quirk\n");
+	}
+
+	if (dmi_check_system(inverted_x_screen)) {
+		ts->prop.invert_x = true;
+		dev_dbg(&ts->client->dev,
+			"Applying 'invert x cooordinate' quirk\n");
 	}
 
 	error = input_mt_init_slots(ts->input_dev, ts->max_touch_num,


### PR DESCRIPTION
In my tablet Cube iwork 10 flagship (I15TC and I15TFL), the touchscreen operates in a mirror manner, this patch fixes this.
P.S. Sorry for my bad english (google translate).